### PR TITLE
Adding basic support for wildcards.

### DIFF
--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -121,11 +121,10 @@ int http_request_on_url(http_parser *parser, const char *at, size_t length)
     http_connection* connection = (http_connection*)parser->data;
     
     // TODO: This should be zero-copy to remove the malloc/strncpy.
-    int buffer_length = sizeof(char) * length + 1;
+    int buffer_length = sizeof(char) * length;
     connection->request->url->value = (char *)malloc(buffer_length);
     connection->request->url->length = buffer_length;
     strncpy(connection->request->url->value, at, length);
-    connection->request->url->value[length] = '\0';
     
     return 0;
 }

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -46,3 +46,7 @@ void string_from_int(hw_string* str, int val, int base)
     str->value = &buf[i+1];
     str->length = length;
 }
+
+int hw_strcmp(hw_string* a, hw_string* b) {
+    return strncmp(a->value, b->value, a->length > b->length ? a->length : b->length);
+}

--- a/src/haywire/hw_string.h
+++ b/src/haywire/hw_string.h
@@ -4,3 +4,4 @@ hw_string* create_string(const char* value);
 void append_string(hw_string* destination, hw_string* source);
 char* dupstr(const char *s);
 void string_from_int(hw_string* str, int val, int base);
+int hw_strcmp(hw_string* a, hw_string* b);

--- a/src/haywire/route_compare_method.c
+++ b/src/haywire/route_compare_method.c
@@ -3,14 +3,87 @@
 #include <string.h>
 #include "route_compare_method.h"
 
-#if defined(_WIN32) || defined(_WIN64)
-    #define strcasecmp _stricmp
-    #define strncasecmp _strnicmp
-    #define strtok_r strtok_s
-#endif
+typedef struct hw_route_token_st {
+    hw_string string;
+    int start;
+} hw_route_token;
+
+void hw_route_next_token(hw_string* url, int start, hw_route_token* result) {
+    while (start < url->length && (url->value[start] == '/')) {
+        start++;
+    }
+    
+    int end = start;
+    
+    while (end < url->length && url->value[end] != '/') {
+        end++;
+    }
+    
+    if (end != start) {
+        result->string.value = url->value + start;
+        result->string.length = end - start;
+        result->start = start;
+    }
+    else {
+        result->string.value = NULL;
+        result->string.length = 0;
+        result->start = -1;
+    }
+}
 
 int hw_route_compare_method(hw_string* url, char* route)
 {
-    int match = strncasecmp(route, url->value, url->length);
-    return (match == 0) ? 1 : 0;
+    int equal = 0;
+    int match = 0;
+    
+    // TODO route should probably be a hw_string* too
+    hw_string hw_route;
+    hw_route.value = route;
+    hw_route.length = strlen(route);
+    
+    hw_route_token route_token;
+    hw_route_token request_token;
+
+    hw_route_next_token(url, 0, &request_token);
+    hw_route_next_token(&hw_route, 0, &route_token);
+    
+    while (route_token.string.value != NULL && request_token.string.value != NULL)
+    {
+        if (route_token.string.value[0] == '*') {
+            // wildcard support: any route fragment marked with '*' matches the corresponding url fragment
+            equal = 1;
+        }
+        else
+        {
+            match = hw_strcmp(route_token.string, request_token.string);
+            if (!match)
+            {
+                equal = 1;
+            }
+            else
+            {
+                equal = 0;
+                break;
+            }
+        }
+        
+        hw_route_next_token(url, request_token.start + request_token.string.length + 1, &request_token);
+        hw_route_next_token(&hw_route, route_token.start + route_token.string.length + 1, &route_token);
+    }
+    
+    if (!equal)
+    {
+        match = hw_strcmp(url, &hw_route);
+        if (!match)
+        {
+            equal = 1;
+        }
+    }
+
+    if ((route_token.string.value == NULL && request_token.string.value != NULL) || (route_token.string.value != NULL && request_token.string.value == NULL))
+    {
+        equal = 0;
+    }
+    
+    return equal;
 }

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -18,6 +18,8 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
     hw_string body;
     hw_string keep_alive_name;
     hw_string keep_alive_value;
+    hw_string route_matched_name;
+    hw_string route_matched_value;
     
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
@@ -42,12 +44,18 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
         hw_set_http_version(response, 1, 0);
     }
     
+    SETSTRING(route_matched_name, "Route-Matched");
+    route_matched_value.value = (char *) user_data;
+    route_matched_value.length = strlen((char *) user_data);
+    hw_set_response_header(response, &route_matched_name, &route_matched_value);
+    
     hw_http_response_send(response, "user_data", response_complete);
 }
 
 int main(int args, char** argsv)
 {
     char route[] = "/";
+    char sub_route[] = "/*";
     configuration config;
     config.http_listen_address = "0.0.0.0";
 
@@ -59,9 +67,11 @@ int main(int args, char** argsv)
     opt_flag_bool(conf, &config.tcp_nodelay, "tcp_nodelay", "If present, enables tcp_nodelay (i.e. disables Nagle's algorithm).");
     args = opt_config_parse(conf, args, argsv);
 
-    /* hw_init_from_config("hello_world.conf"); */
     hw_init_with_config(&config);
-    hw_http_add_route(route, get_root, NULL);
+    
+    hw_http_add_route(route, get_root, route);
+    hw_http_add_route(sub_route, get_root, sub_route);
+    
     hw_http_open();
 
     opt_config_free(conf);


### PR DESCRIPTION
This means that it will now be possible to map a handler to `/*` that will be used for requests such as `/foo` and `/bar/`. It will also allow you to define `/*/*` that will match `/foo/bar` but not `/foo`.