### PR TITLE
Removing copy of headers and using hw_string instead to represent them. Removing copy of body too.

### DIFF
--- a/benchmark/pipelined_get_headers.lua
+++ b/benchmark/pipelined_get_headers.lua
@@ -1,0 +1,21 @@
+arguments = {}
+
+init = function(args)
+    arguments = args
+    wrk.headers["X-Small"] = "Small value"
+    wrk.headers["X-Medium"] = "Some header with a medium value"
+    wrk.headers["X-Large"] = "Some header with a reasonably large value that will take a bit more memory, just like most user agent strings"
+end
+
+request = function()
+    pipeline_length = tonumber(arguments[1]) or 1
+    local r = {}
+
+    for i=1,pipeline_length do
+        r[i] = wrk.format("GET", "/")
+    end
+
+    req = table.concat(r)
+
+    return req
+end

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -172,7 +172,7 @@ HAYWIRE_EXTERN int hw_init_from_config(char* configuration_filename);
 HAYWIRE_EXTERN int hw_init_with_config(configuration* config);
 HAYWIRE_EXTERN int hw_http_open();
 HAYWIRE_EXTERN void hw_http_add_route(char* route, http_request_callback callback, void* user_data);
-HAYWIRE_EXTERN char* hw_get_header(http_request* request, char* key);
+HAYWIRE_EXTERN hw_string* hw_get_header(http_request* request, hw_string* key);
 
 HAYWIRE_EXTERN void hw_free_http_response(hw_http_response* response);
 HAYWIRE_EXTERN void hw_set_http_version(hw_http_response* response, unsigned short major, unsigned short minor);

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -9,10 +9,8 @@ typedef struct
     http_parser parser;
     uv_write_t write_req;
     http_request* request;
-    char current_header_key[1024];
-    int current_header_key_length;
-    char current_header_value[1024];
-    int current_header_value_length;
+    hw_string current_header_key;
+    hw_string current_header_value;
     int keep_alive;
     int last_was_value;
 } http_connection;

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -303,6 +303,7 @@ int http_request_on_message_complete(http_parser* parser)
         // 404 Not Found.
         write_context = malloc(sizeof(hw_write_context));
         write_context->connection = connection;
+        write_context->request = connection->request;
         write_context->callback = 0;
         get_404_response(connection->request, (http_response*)response);
         response_buffer = create_response_buffer(response);
@@ -321,6 +322,7 @@ void hw_http_response_send(hw_http_response* response, void* user_data, http_res
     hw_string* response_buffer = create_response_buffer(response);
     
     write_context->connection = resp->connection;
+    write_context->request = resp->connection->request;
     write_context->user_data = user_data;
     write_context->callback = callback;
     http_server_write_response(write_context, response_buffer);

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -93,7 +93,6 @@ void set_header(http_request* request, hw_string* name, hw_string* value)
 http_request* create_http_request(http_connection* connection)
 {
     http_request* request = malloc(sizeof(http_request));
-    request->url = NULL;
     request->headers = kh_init(hw_string_hashmap);
     request->url = malloc(sizeof(hw_string));
     request->url->length = 0;
@@ -117,7 +116,11 @@ void free_http_request(http_request* request)
         free((hw_string*)v);
     });
     kh_destroy(hw_string_hashmap, request->headers);
-    
+
+    if (request->url->length > 0)
+    {
+        free(request->url->value);
+    }
     free(request->url); 
     free(request->body);
     free(request);

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -312,6 +312,9 @@ int http_request_on_message_complete(http_parser* parser)
         hw_free_http_response(response);
     }
     
+    free_http_request(connection->request);
+    connection->request = NULL;
+    
     return 0;
 }
 

--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -111,6 +111,10 @@ http_connection* create_http_connection()
 
 void free_http_connection(http_connection* connection)
 {
+    if (connection->request != NULL)
+    {
+        free_http_request(connection->request);
+    }
     free(connection);
     INCREMENT_STAT(stat_connections_destroyed_total);
 }
@@ -303,9 +307,6 @@ void http_server_after_write(uv_write_t* req, int status)
         write_context->callback(write_context->user_data);
     }
     
-    if (write_context->request != NULL) {
-	  free_http_request(write_context->request);
-    }
     write_context->request = NULL;
 
     free(write_context);

--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -111,11 +111,6 @@ http_connection* create_http_connection()
 
 void free_http_connection(http_connection* connection)
 {
-    if (connection->request != NULL)
-    {
-        free_http_request(connection->request);
-    }
-    
     free(connection);
     INCREMENT_STAT(stat_connections_destroyed_total);
 }
@@ -308,10 +303,10 @@ void http_server_after_write(uv_write_t* req, int status)
         write_context->callback(write_context->user_data);
     }
     
-    if (write_context->connection->request != NULL) {
-	  free_http_request(write_context->connection->request);
+    if (write_context->request != NULL) {
+	  free_http_request(write_context->request);
     }
-    write_context->connection->request = NULL;
+    write_context->request = NULL;
 
     free(write_context);
     free(resbuf->base);

--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -102,6 +102,9 @@ http_connection* create_http_connection()
 {
     http_connection* connection = malloc(sizeof(http_connection));
     connection->request = NULL;
+    connection->current_header_key.length = 0;
+    connection->current_header_value.length = 0;
+    connection->last_was_value = 0;
     INCREMENT_STAT(stat_connections_created_total);
     return connection;
 }
@@ -305,6 +308,11 @@ void http_server_after_write(uv_write_t* req, int status)
         write_context->callback(write_context->user_data);
     }
     
+    if (write_context->connection->request != NULL) {
+	  free_http_request(write_context->connection->request);
+    }
+    write_context->connection->request = NULL;
+
     free(write_context);
     free(resbuf->base);
     free(req);    

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -13,6 +13,7 @@ typedef struct
 typedef struct
 {
     http_connection* connection;
+    http_request* request;
     void* user_data;
     http_response_complete_callback callback;
 } hw_write_context;

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -13,6 +13,18 @@ hw_string* create_string(const char* value)
     return str;
 }
 
+hw_string* hw_strdup(hw_string* tocopy)
+{
+    hw_string* str = malloc(sizeof(hw_string));
+    str->value = tocopy->value;
+    str->length = tocopy->length;
+    return str;
+}
+
+int hw_strcmp(hw_string* a, hw_string* b) {
+    return strncmp(a->value, b->value, a->length > b->length ? a->length : b->length);
+}
+
 void append_string(hw_string* destination, hw_string* source)
 {
     void* location = (char*)destination->value + destination->length;

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -58,7 +58,3 @@ void string_from_int(hw_string* str, int val, int base)
     str->value = &buf[i+1];
     str->length = length;
 }
-
-int hw_strcmp(hw_string* a, hw_string* b) {
-    return strncmp(a->value, b->value, a->length > b->length ? a->length : b->length);
-}

--- a/src/haywire/hw_string.h
+++ b/src/haywire/hw_string.h
@@ -1,6 +1,8 @@
 #pragma once
 
 hw_string* create_string(const char* value);
+int hw_strcmp(hw_string* a, hw_string* b);
+hw_string* hw_strdup(hw_string* tocopy);
 void append_string(hw_string* destination, hw_string* source);
 char* dupstr(const char *s);
 void string_from_int(hw_string* str, int val, int base);


### PR DESCRIPTION
This is my first PR to address #75.

In this PR, I've removed the need to memcpy header keys and values. I've also changed the body to point to a hw_string, and not having to realloc/free upon receiving body chunks.

I don't currently have access to AWS machines to test this, so I had to test it in my local machine only for now. I can't see significant differences between my changes and master, but I'd like to get your thoughts on this @kellabyte before investing any more time.

I added another lua script (pipelined_get_headers.lua) to push some headers to the server as part of the benchmark.

I'll benchmark this with two separate servers some time next week.

Merry Christmas :santa: 

PS: I opened #80 as I think we're at a point where we need a more sophisticated benchmark server.