### PR TITLE
Using uv_buf_init on the allocation callback, to ensure platform-inde…

### DIFF
--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -245,8 +245,8 @@ void http_stream_on_connect(uv_stream_t* stream, int status)
 
 void http_stream_on_alloc(uv_handle_t* client, size_t suggested_size, uv_buf_t* buf)
 {
-    buf->base = malloc(suggested_size);
-    buf->len = suggested_size;
+    void* new_buf = malloc(suggested_size);
+    *buf = uv_buf_init(new_buf, suggested_size);
 }
 
 void http_stream_on_close(uv_handle_t* handle)


### PR DESCRIPTION
…pendent buffer initialization. Fixes #87 

Performance is virtually unchanged as expected.

### master
```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 300 -t 300 -d 1m -s pipelined_get.lua  --latency http://172.31.5.65:8000 -- 64
Running 1m test @ http://172.31.5.65:8000
  300 threads and 300 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   107.82ms  179.35ms   1.78s    91.08%
    Req/Sec     2.48k     1.58k   56.89k    63.20%
  Latency Distribution
     50%   26.78ms
     75%  151.56ms
     90%  262.83ms
     99%  873.93ms
  34326134 requests in 1.00m, 5.63GB read
  Socket errors: connect 0, read 0, write 0, timeout 39
Requests/sec: 571143.78
Transfer/sec:     95.86MB
```

### this change
```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 300 -t 300 -d 1m -s pipelined_get.lua  --latency http://172.31.5.65:8000 -- 64
Running 1m test @ http://172.31.5.65:8000
  300 threads and 300 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   108.06ms  177.42ms   1.81s    91.01%
    Req/Sec     2.48k     1.64k   47.84k    63.81%
  Latency Distribution
     50%   28.78ms
     75%  152.39ms
     90%  263.28ms
     99%  842.94ms
  34361410 requests in 1.00m, 5.63GB read
  Socket errors: connect 0, read 0, write 0, timeout 34
Requests/sec: 571727.20
Transfer/sec:     95.96MB
```