### PR TITLE
Reallocating buffers as required and supporting partial reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,9 @@ build/
 
 # Lazily-resolved dependencies
 lib/
+
+# Xcode
+Haywire.xcworkspace/
+
+# CLion
 .idea

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -149,6 +149,7 @@ typedef struct
     int thread_count;
     char* parser;
     bool tcp_nodelay;
+    int max_request_size;
 } configuration;
     
 typedef struct
@@ -161,6 +162,7 @@ typedef struct
     void* headers;
     hw_string* body;
     size_t body_length;
+    bool size_exceeded;
 } http_request;
 
 typedef	void* hw_http_response;

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -145,11 +145,11 @@ typedef struct
 typedef struct
 {
     char* http_listen_address;
-    int http_listen_port;
-    int thread_count;
+    unsigned int http_listen_port;
+    unsigned int thread_count;
     char* parser;
     bool tcp_nodelay;
-    int max_request_size;
+    unsigned int max_request_size;
 } configuration;
     
 typedef struct

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -150,7 +150,7 @@ typedef struct
     char* parser;
     bool tcp_nodelay;
 } configuration;
-
+    
 typedef struct
 {
     unsigned short http_major;
@@ -160,7 +160,7 @@ typedef struct
     hw_string* url;
     void* headers;
     hw_string* body;
-    int body_length;
+    size_t body_length;
 } http_request;
 
 typedef	void* hw_http_response;

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -145,13 +145,14 @@ typedef struct
 typedef struct
 {
     char* http_listen_address;
-    unsigned int http_listen_port;
-    unsigned int thread_count;
+    int http_listen_port;
+    int thread_count;
     char* parser;
     bool tcp_nodelay;
     unsigned int max_request_size;
+    unsigned int listen_backlog;
 } configuration;
-    
+
 typedef struct
 {
     unsigned short http_major;

--- a/src/haywire/connection_consumer.c
+++ b/src/haywire/connection_consumer.c
@@ -121,7 +121,7 @@ void connection_consumer_start(void *arg)
     get_listen_handle(loop, (uv_stream_t*) &ctx->server_handle);
     uv_sem_post(&ctx->semaphore);
     
-    rc = uv_listen((uv_stream_t*)&ctx->server_handle, 128, connection_consumer_new_connection);
+    rc = uv_listen((uv_stream_t*)&ctx->server_handle, ctx->listen_backlog, connection_consumer_new_connection);
     rc = uv_run(loop, UV_RUN_DEFAULT);
     
     uv_loop_delete(loop);

--- a/src/haywire/connection_consumer.h
+++ b/src/haywire/connection_consumer.h
@@ -27,6 +27,7 @@ struct server_ctx
     uv_thread_t thread_id;
     uv_sem_t semaphore;
     bool tcp_nodelay;
+    unsigned int listen_backlog;
 };
 
 struct ipc_client_ctx

--- a/src/haywire/connection_dispatcher.c
+++ b/src/haywire/connection_dispatcher.c
@@ -59,7 +59,7 @@ void ipc_connection_cb(uv_stream_t* ipc_pipe, int status)
  * threads. It's kind of cumbersome for such a simple operation, maybe we
  * should revive uv_import() and uv_export().
  */
-void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay)
+void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay, int listen_backlog)
 {
     int rc;
     struct ipc_server_ctx ctx;
@@ -87,7 +87,7 @@ void start_connection_dispatching(uv_handle_type type, unsigned int num_servers,
     
     rc = uv_pipe_init(loop, &ctx.ipc_pipe, 1);
     rc = uv_pipe_bind(&ctx.ipc_pipe, "HAYWIRE_CONNECTION_DISPATCH_PIPE_NAME");
-    rc = uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb);
+    rc = uv_listen((uv_stream_t*) &ctx.ipc_pipe, listen_backlog, ipc_connection_cb);
     
     for (i = 0; i < num_servers; i++)
         uv_sem_post(&servers[i].semaphore);

--- a/src/haywire/connection_dispatcher.h
+++ b/src/haywire/connection_dispatcher.h
@@ -9,4 +9,4 @@ struct ipc_peer_ctx
     uv_write_t write_req;
 };
 
-void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay);
+void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay, int listen_backlog);

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #pragma once
 #include "uv.h"
 #include "http_parser.h"
@@ -9,8 +11,12 @@ typedef struct
     http_parser parser;
     uv_write_t write_req;
     http_request* request;
+    http_request_offsets offsets;
     hw_string current_header_key;
     hw_string current_header_value;
     int keep_alive;
     int last_was_value;
+    size_t buffer_size;
+    size_t buffer_used;
+    void* buffer;
 } http_connection;

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -110,6 +110,7 @@ http_request* create_http_request(http_connection* connection)
 void free_http_request(http_request* request)
 {
     khash_t(hw_string_hashmap) *h = request->headers;
+
     hw_string* k;
     hw_string* v;
     kh_foreach(h, k, v,
@@ -117,8 +118,9 @@ void free_http_request(http_request* request)
         free((hw_string*)k);
         free((hw_string*)v);
     });
-    kh_destroy(hw_string_hashmap, request->headers);
-    free(request->url); 
+    kh_destroy(hw_string_hashmap, h);
+    
+    free(request->url);
     free(request->body);
     free(request);
     INCREMENT_STAT(stat_requests_destroyed_total);
@@ -328,9 +330,6 @@ int http_request_on_message_complete(http_parser* parser)
         http_request_reset_offsets(&connection->offsets);
     }
 
-    free_http_request(connection->request);
-    connection->request = NULL;
-    
     return 0;
 }
 

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -142,8 +142,12 @@ int http_request_on_message_begin(http_parser* parser)
 int http_request_on_url(http_parser *parser, const char *at, size_t length)
 {
     http_connection* connection = (http_connection*)parser->data;
-    connection->request->url->value = at;
-    connection->request->url->length = length;
+    if (connection->request->url->length) {
+        connection->request->url->length += length;
+    } else {
+        connection->request->url->value = at;
+        connection->request->url->length = length;
+    }
     
     return 0;
 }

--- a/src/haywire/http_request.h
+++ b/src/haywire/http_request.h
@@ -1,8 +1,19 @@
+#include <stddef.h>
+
 #pragma once
 #include "uv.h"
 #include "http_parser.h"
 
 extern int last_was_value;
+
+typedef struct
+{
+    void* header_name_offsets;
+    void* header_value_offsets;
+    unsigned int body_offset;
+    unsigned int url_offset;
+    int in_use;
+} http_request_offsets;
 
 void free_http_request(http_request* request);
 int http_request_on_message_begin(http_parser *parser);
@@ -12,3 +23,7 @@ int http_request_on_header_value(http_parser *parser, const char *at, size_t len
 int http_request_on_body(http_parser *parser, const char *at, size_t length);
 int http_request_on_headers_complete(http_parser *parser);
 int http_request_on_message_complete(http_parser *parser);
+void http_request_update_offsets(void* old_buffer, void* new_buffer, http_request_offsets* offsets, http_request* request);
+void http_request_commit_offsets(void* buffer, http_request_offsets* offsets, http_request* request);
+void http_request_reset_offsets(http_request_offsets* offsets);
+void free_http_request_offsets(http_request_offsets* offsets);

--- a/src/haywire/http_response.c
+++ b/src/haywire/http_response.c
@@ -82,7 +82,7 @@ hw_string* create_response_buffer(hw_http_response* response)
     int line_sep_size = sizeof(CRLF);
 
     int header_buffer_incr = 512;
-    int body_size = resp->body.length + line_sep_size;
+    int body_size = resp->body.length;
     int header_size_remaining = header_buffer_incr;
     int response_size = header_size_remaining + sizeof(length_header) + num_chars(resp->body.length) + 2 * line_sep_size + body_size + line_sep_size;
 
@@ -112,14 +112,22 @@ hw_string* create_response_buffer(hw_http_response* response)
     APPENDSTRING(response_string, length_header);
 
     string_from_int(&content_length, body_size, 10);
-    append_string(response_string, &content_length);
+    
+    if (body_size > 0) {
+        append_string(response_string, &content_length);
+    }
+    else {
+        hw_string zero_content;
+        zero_content.value = "0";
+        zero_content.length = 1;
+        append_string(response_string, &zero_content);
+    }
+    
     APPENDSTRING(response_string, CRLF CRLF);
     
-    if (resp->body.length > 0)
+    if (body_size > 0)
     {
         append_string(response_string, &resp->body);
     }
-    APPENDSTRING(response_string, CRLF);
-    response_string->value[response_string->length] = '\0';
     return response_string;
 }

--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -255,8 +255,8 @@ void http_stream_on_connect(uv_stream_t* stream, int status)
 
 void http_stream_on_alloc(uv_handle_t* client, size_t suggested_size, uv_buf_t* buf)
 {
-    buf->base = malloc(suggested_size);
-    buf->len = suggested_size;
+    void* new_buf = malloc(suggested_size);
+    *buf = uv_buf_init(new_buf, suggested_size);
 }
 
 void http_stream_on_close(uv_handle_t* handle)

--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -55,13 +55,6 @@ uv_async_t* listener_async_handles;
 uv_loop_t* listener_event_loops;
 uv_barrier_t* listeners_created_barrier;
 
-void signal_handler(int signal)
-{
-    // TODO: We should clean up initialization leak gracefully.
-    // https://github.com/haywire/Haywire/pull/83
-    exit(EXIT_SUCCESS);
-}
-
 int hw_init_with_config(configuration* c)
 {
     int http_listen_address_length;
@@ -181,7 +174,6 @@ int hw_http_open()
     
 #ifdef UNIX
     signal(SIGPIPE, SIG_IGN);
-    signal(SIGINT, signal_handler);
 #endif // UNIX
     
     listener_count = threads;

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -22,7 +22,23 @@ hw_string* hw_strdup(hw_string* tocopy)
 }
 
 int hw_strcmp(hw_string* a, hw_string* b) {
-    return strncmp(a->value, b->value, a->length > b->length ? a->length : b->length);
+    int ret;
+    
+    if (a->length > b->length) {
+        ret = strncmp(a->value, b->value, b->length);
+        if (!ret) {
+            ret = 1;
+        }
+    } else if (a->length == b->length) {
+        ret = strncmp(a->value, b->value, a->length);
+    } else {
+        ret = strncmp(a->value, b->value, a->length);
+        if (!ret) {
+            ret = -1;
+        }
+    }
+    
+    return ret;
 }
 
 void append_string(hw_string* destination, hw_string* source)

--- a/src/haywire/route_compare_method.c
+++ b/src/haywire/route_compare_method.c
@@ -55,7 +55,7 @@ int hw_route_compare_method(hw_string* url, char* route)
         }
         else
         {
-            match = hw_strcmp(route_token.string, request_token.string);
+            match = hw_strcmp(&route_token.string, &request_token.string);
             if (!match)
             {
                 equal = 1;

--- a/src/samples/hello_world/haywire_hello_world.conf
+++ b/src/samples/hello_world/haywire_hello_world.conf
@@ -5,3 +5,4 @@
 listen_address = 0.0.0.0
 listen_port = 8000
 tcp_nodelay = 1
+max_request_size = 1048576

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -21,6 +21,9 @@ void get_ping(http_request* request, hw_http_response* response, void* user_data
     hw_string route_matched_name;
     hw_string route_matched_value;
     
+    hw_print_request_headers(request);
+    hw_print_body(request);
+    
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
     
@@ -88,7 +91,8 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
 
 int main(int args, char** argsv)
 {
-    char route[] = "/";
+    char root_route[] = "/";
+    char ping_route[] = "/ping";
     configuration config;
     config.http_listen_address = "0.0.0.0";
 
@@ -97,12 +101,14 @@ int main(int args, char** argsv)
     opt_flag_int(conf, &config.http_listen_port, "port", 8000, "Port to listen on.");
     opt_flag_int(conf, &config.thread_count, "threads", 0, "Number of threads to use.");
     opt_flag_string(conf, &config.parser, "parser", "http_parser", "HTTP parser to use");
+    opt_flag_int(conf, &config.max_request_size, "max_request_size", 1048576, "Maximum request size. Defaults to 1MB.");
     opt_flag_bool(conf, &config.tcp_nodelay, "tcp_nodelay", "If present, enables tcp_nodelay (i.e. disables Nagle's algorithm).");
     args = opt_config_parse(conf, args, argsv);
 
     hw_init_with_config(&config);
     
-    hw_http_add_route(route, get_ping, NULL);
+    hw_http_add_route(ping_route, get_ping, NULL);
+    hw_http_add_route(root_route, get_root, NULL);
     
     hw_http_open();
 

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -10,6 +10,45 @@ void response_complete(void* user_data)
 {
 }
 
+void get_ping(http_request* request, hw_http_response* response, void* user_data)
+{
+    hw_string status_code;
+    hw_string content_type_name;
+    hw_string content_type_value;
+    hw_string body;
+    hw_string keep_alive_name;
+    hw_string keep_alive_value;
+    hw_string route_matched_name;
+    hw_string route_matched_value;
+    
+    SETSTRING(status_code, HTTP_STATUS_200);
+    hw_set_response_status_code(response, &status_code);
+    
+    SETSTRING(content_type_name, "Content-Type");
+    
+    SETSTRING(content_type_value, "text/html");
+    hw_set_response_header(response, &content_type_name, &content_type_value);
+    
+    body.value = request->body->value;
+    body.length = request->body->length;
+    hw_set_body(response, &body);
+    
+    if (request->keep_alive)
+    {
+        SETSTRING(keep_alive_name, "Connection");
+        
+        SETSTRING(keep_alive_value, "Keep-Alive");
+        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
+    }
+    else
+    {
+        hw_set_http_version(response, 1, 0);
+    }
+    
+    hw_http_response_send(response, "user_data", response_complete);
+}
+
+
 void get_root(http_request* request, hw_http_response* response, void* user_data)
 {
     hw_string status_code;
@@ -44,18 +83,12 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
         hw_set_http_version(response, 1, 0);
     }
     
-    SETSTRING(route_matched_name, "Route-Matched");
-    route_matched_value.value = (char *) user_data;
-    route_matched_value.length = strlen((char *) user_data);
-    hw_set_response_header(response, &route_matched_name, &route_matched_value);
-    
     hw_http_response_send(response, "user_data", response_complete);
 }
 
 int main(int args, char** argsv)
 {
     char route[] = "/";
-    char sub_route[] = "/*";
     configuration config;
     config.http_listen_address = "0.0.0.0";
 
@@ -69,8 +102,7 @@ int main(int args, char** argsv)
 
     hw_init_with_config(&config);
     
-    hw_http_add_route(route, get_root, route);
-    hw_http_add_route(sub_route, get_root, sub_route);
+    hw_http_add_route(route, get_ping, NULL);
     
     hw_http_open();
 

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <haywire.h>
 #include "opt.h"
 #include "haywire.h"
 
@@ -103,6 +104,7 @@ int main(int args, char** argsv)
     opt_flag_string(conf, &config.parser, "parser", "http_parser", "HTTP parser to use");
     opt_flag_int(conf, &config.max_request_size, "max_request_size", 1048576, "Maximum request size. Defaults to 1MB.");
     opt_flag_bool(conf, &config.tcp_nodelay, "tcp_nodelay", "If present, enables tcp_nodelay (i.e. disables Nagle's algorithm).");
+    opt_flag_int(conf, &config.listen_backlog, "listen_backlog", 0, "Maximum size of the backlog when accepting connection. Defaults to SOMAXCONN.");
     args = opt_config_parse(conf, args, argsv);
 
     hw_init_with_config(&config);


### PR DESCRIPTION
Fixes #87 and #88.

haywire will now keep allocating memory until the request is completely parsed.

Previously, we were assuming that the alloc callback was only called once per request and that the read callback was called when all the data was available.
Unfortunately, that's not the case, and the read callback may be called when only a fraction of the incoming data is available, especially under high concurrency.

To work around this, we allocate/reallocate the request buffer as required to keep up with the incoming data. Since the buffer may be reallocated to a different memory region, we save the offset for the URL, headers and the body in the original buffer and then repoint all of them when we finish parsing the request, so that they're in the same position in relation to the beginning of the final request buffer.

I've also fixed a couple of minor bugs with route comparison and added a ping endpoint. 

Another thing I noticed was that we were adding "\r\n\0" to all responses, which I don't think is correct, so I removed those three chars from the response. 

As usual, here are some test runs (on 2 AWS m4.xlarge machines):

### My changes:
```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 300 -t 300 -d 1m -s pipelined_get.lua  --latency http://172.31.5.65:8000 -- 64
Running 1m test @ http://172.31.5.65:8000
  300 threads and 300 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    94.87ms  160.65ms   1.94s    91.83%
    Req/Sec     2.73k     1.74k   45.84k    55.11%
  Latency Distribution
     50%   22.09ms
     75%  137.66ms
     90%  226.44ms
     99%  781.10ms
  38989840 requests in 1.00m, 5.63GB read
  Socket errors: connect 0, read 0, write 0, timeout 27
Requests/sec: 648751.08
Transfer/sec:     95.90MB
```

### master
```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 300 -t 300 -d 1m -s pipelined_get.lua  --latency http://172.31.5.65:8000 -- 64
Running 1m test @ http://172.31.5.65:8000
  300 threads and 300 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   106.50ms  172.93ms   1.90s    90.99%
    Req/Sec     2.48k     1.60k   48.01k    63.00%
  Latency Distribution
     50%   28.03ms
     75%  152.31ms
     90%  260.85ms
     99%  822.58ms
  34498011 requests in 1.00m, 5.65GB read
  Socket errors: connect 0, read 0, write 0, timeout 30
Requests/sec: 574008.87
Transfer/sec:     96.34MB
```

In addition to those, I've also played with body sizes of 1kB and 1MB, to ensure that the size validation works:

* Creating 1kB and 1MB files and generating base64 representations of them, so I can see them on the terminal
```
fallocate -l 1K 1kb.dat
fallocate -l 1M 1mb.dat
openssl base64 -in 1kb.dat -out 1kb-base64.dat
openssl base64 -in 1mb.dat -out 1mb-base64.dat
```

* Uploading the 1kB file and checking that we get identical content back:
```
[ec2-user@ip-172-31-5-244 ~]$ 
curl -s http://172.31.5.65:8000/ping --data-binary @1kb-base64.dat -o 1kb-base64.dat.out -v
*   Trying 172.31.5.65...
* Connected to 172.31.5.65 (172.31.5.65) port 8000 (#0)
> POST /ping HTTP/1.1
> User-Agent: curl/7.40.0
> Host: 172.31.5.65:8000
> Accept: */*
> Content-Length: 1390
> Content-Type: application/x-www-form-urlencoded
> Expect: 100-continue
>
* Done waiting for 100-continue
} [1390 bytes data]
< HTTP/1.1 200 OK
< Server: Haywire/master
< Date: Tue Jan 19 09:52:01 2016
< Content-Type: text/html
< Connection: Keep-Alive
< Content-Length: 1390
<
{ [1390 bytes data]
* Connection #0 to host 172.31.5.65 left intact

[ec2-user@ip-172-31-5-244 ~]$ diff 1kb-base64.dat 1kb-base64.dat.out -s
Files 1kb-base64.dat and 1kb-base64.dat.out are identical
```

* Uploading the 1MB file and getting a 413
```
[ec2-user@ip-172-31-5-244 ~]$ curl -s http://172.31.5.65:8000/ping --data-binary @1mb-base64.dat -v
*   Trying 172.31.5.65...
* Connected to 172.31.5.65 (172.31.5.65) port 8000 (#0)
> POST /ping HTTP/1.1
> User-Agent: curl/7.40.0
> Host: 172.31.5.65:8000
> Accept: */*
> Content-Length: 1419950
> Content-Type: application/x-www-form-urlencoded
> Expect: 100-continue
>
* Done waiting for 100-continue
< HTTP/1.1 413 Req
< Server: Haywire/master
< Date: Tue Jan 19 10:10:43 2016
< Content-Type: text/html
< Connection: Keep-Alive
< Content-Length: 28
* HTTP error before end of send, stop sending
<
* Closing connection 0
413 Request Entity Too Large[ec2-user@ip-172-31-5-244 ~]$
```