### PR TITLE
Making listen backlog configurable.

### DIFF
--- a/include/haywire.h
+++ b/include/haywire.h
@@ -145,10 +145,11 @@ typedef struct
 typedef struct
 {
     char* http_listen_address;
-    int http_listen_port;
-    int thread_count;
+    unsigned int http_listen_port;
+    unsigned int thread_count;
     char* parser;
     bool tcp_nodelay;
+    unsigned int listen_backlog;
 } configuration;
 
 typedef struct

--- a/src/haywire/connection_consumer.c
+++ b/src/haywire/connection_consumer.c
@@ -121,7 +121,7 @@ void connection_consumer_start(void *arg)
     get_listen_handle(loop, (uv_stream_t*) &ctx->server_handle);
     uv_sem_post(&ctx->semaphore);
     
-    rc = uv_listen((uv_stream_t*)&ctx->server_handle, 128, connection_consumer_new_connection);
+    rc = uv_listen((uv_stream_t*)&ctx->server_handle, ctx->listen_backlog, connection_consumer_new_connection);
     rc = uv_run(loop, UV_RUN_DEFAULT);
     
     uv_loop_delete(loop);

--- a/src/haywire/connection_consumer.h
+++ b/src/haywire/connection_consumer.h
@@ -27,6 +27,7 @@ struct server_ctx
     uv_thread_t thread_id;
     uv_sem_t semaphore;
     bool tcp_nodelay;
+    unsigned int listen_backlog;
 };
 
 struct ipc_client_ctx

--- a/src/haywire/connection_dispatcher.c
+++ b/src/haywire/connection_dispatcher.c
@@ -59,7 +59,7 @@ void ipc_connection_cb(uv_stream_t* ipc_pipe, int status)
  * threads. It's kind of cumbersome for such a simple operation, maybe we
  * should revive uv_import() and uv_export().
  */
-void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay)
+void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay, int listen_backlog)
 {
     int rc;
     struct ipc_server_ctx ctx;
@@ -87,7 +87,7 @@ void start_connection_dispatching(uv_handle_type type, unsigned int num_servers,
     
     rc = uv_pipe_init(loop, &ctx.ipc_pipe, 1);
     rc = uv_pipe_bind(&ctx.ipc_pipe, "HAYWIRE_CONNECTION_DISPATCH_PIPE_NAME");
-    rc = uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb);
+    rc = uv_listen((uv_stream_t*) &ctx.ipc_pipe, listen_backlog, ipc_connection_cb);
     
     for (i = 0; i < num_servers; i++)
         uv_sem_post(&servers[i].semaphore);

--- a/src/haywire/connection_dispatcher.h
+++ b/src/haywire/connection_dispatcher.h
@@ -9,4 +9,4 @@ struct ipc_peer_ctx
     uv_write_t write_req;
 };
 
-void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay);
+void start_connection_dispatching(uv_handle_type type, unsigned int num_servers, struct server_ctx* servers, char* listen_address, int listen_port, bool tcp_nodelay, int listen_backlog);

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <haywire.h>
 #include "opt.h"
 #include "haywire.h"
 
@@ -65,6 +66,7 @@ int main(int args, char** argsv)
     opt_flag_int(conf, &config.thread_count, "threads", 0, "Number of threads to use.");
     opt_flag_string(conf, &config.parser, "parser", "http_parser", "HTTP parser to use");
     opt_flag_bool(conf, &config.tcp_nodelay, "tcp_nodelay", "If present, enables tcp_nodelay (i.e. disables Nagle's algorithm).");
+    opt_flag_int(conf, &config.listen_backlog, "listen_backlog", 0, "Maximum size of the backlog when accepting connection. Defaults to SOMAXCONN.");
     args = opt_config_parse(conf, args, argsv);
 
     hw_init_with_config(&config);


### PR DESCRIPTION
@kellabyte I didn't really run a benchmark for this change as it has no effect on performance by default (SOMAXCONN is 128 anyway). Also, I think the tools we use to benchmark first establish all connections anyway.