### PR TITLE
haywire will now keep allocating memory as required, as it's not guar…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,9 @@ build/
 
 # Lazily-resolved dependencies
 lib/
+
+# Xcode
+Haywire.xcworkspace/
+
+# CLion
 .idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ include("common.cmake")
 # ----------------------------------------
 project(haywire C)
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
-#set(CMAKE_BUILD_TYPE Debug)
 
 add_definitions(-std=gnu99)
 #add_definitions(-mavx)

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -1,0 +1,211 @@
+# Buffer management
+
+Haywire allocates buffers dynamically, allowing them to be extended as required to accommodate the data being read by libuv. Buffers are limited to 1MB by default to avoid having the caller exhaust the available memory on the server.
+
+## Buffer chunks
+
+By default, Haywire allocates a new buffer that is 64KB long. libuv doesn't have access to the entire underlying buffer space, as buffer management is abstracted away to allow buffer re-use.
+
+Initially, the buffer is seen as a big 64KB chunk that is handed over to libuv so it can read data into it. However, since libuv may use only a fraction of that buffer, subsequent buffer requests will most likely be served by returning free space within the current underlying buffer.
+
+Whenever libuv asks for a new buffer, Haywire returns the remaining free space in the buffer as a chunk of memory that libuv can read data into.
+
+Example:
+1) libuv requests a 64KB chunk
+2) Haywire allocated a 64KB buffer and returns a buffer chunk that overlaps the entire buffer and is 64KB long
+3) libuv reads 10k bytes into that chunk of memory and passes it onto to Haywire for parsing
+4) libuv requests another 64KB chunk to read more incoming data
+5) Haywire sees that the buffer still has 54k bytes free, it returns that free space as a 54KB chunk, starting at a 10KB offset since the beginning of the underlying buffer.
+
+
+libuv and Haywire keep using the same buffer until the buffer reaches a sufficiently high level of usage (currently 50%), at which time Haywire reallocates the underlying buffer (see [Dynamic reallocation](#dynamic-reallocation)). In practice, unless requests are pipelined and come in batches big enough to use more than 50% of the buffer or unless the request is big enough to use more than 50% of the buffer, reallocation doesn't really happen, as Haywire continuously sweeps old data away from the buffer (see [Buffer housekeeping](#buffer-housekeeping)).
+
+## Dynamic reallocation
+
+Since buffers are extended by calling `realloc`, it's possible that the buffer will be moved around as the request is being processed. Therefore, Haywire places pins on certain pointers (e.g. URL start, header start, body start) as it parses requests in the buffer. When a new pin is created, Haywire calculates the pointer offset on the request buffer (i.e. difference between the pointer value and the request buffer start pointer) and that offset can then be used to locate the original pointer (e.g. URL start) even when the buffer is relocated by `realloc`. Once the request is fully parsed, Haywire locates all the pins and recalculates pointers so that none of them are dangling in the event of a buffer relocation.
+
+Example:
+
+```
+
+1) A 512KB request is partially read into a 64KB buffer
+
++--------------------------------------------------------------------------------------+
+| POST / HTTP/1.1\r\nHost: someserver.com\r\nLorem ipsum dolor sit amet, .........     |
++--------------------------------------------------------------------------------------+
+
+2) Haywire finds the URL position 5, the Host header at position 17, the header value at position 23 and
+the start of the body at position 39. Therefore, it places the following pins:
+
+    url pin => key = request->url pointer; offset = 5
+    host header name pin => key = host header name pointer; offset = 17
+    host header value pin => key = host header value pointer; offset = 23
+    body pin => key = request->body pointer; offset = 39
+
+3) libuv requests another chunk. Since the buffer is full, it it gets resized with realloc
+and (in this example) no longer starts at the same location it did previously. Therefore,
+the URL, host value/key and body pointers are now invalid.
+
+4) libuv and Haywire keep processing the request and eventually the request is completely parsed.
+Haywire then locates all the pins and recalculates the pointers.
+
+   Example (pseudo-code):
+      url_pointer := locate(key = URL pointer)
+
+      locate(key) = buffer start + offset(key)
+
+5) The request callback can now safely execute as the request is stored in the buffer just as
+if it had been read in one go.
+
+```
+
+
+## Buffer housekeeping
+
+To keep the memory footprint low, Haywire uses a mark/sweep approach to discard the raw data for requests that have been fully parsed and executed. The following diagrams shows an example of how Haywire handles cleans up the buffer as it processes requests.
+
+
+```
+1) The client starts sending requests and libuv requests a new buffer,
+hinting at a size of 64KB by default.
+
+2) Haywire allocates a new buffer that is 64KB long.
+Initially, the buffer is seen as a big 64KB chunk, but as libuv consumes part of it,
+subsequent memory requests are served from within the bufferSince libuv may not
+use all of the 64KB and returns that a single 64KB chunk back to libuv.
+
++ buffer
+|
+|
++-> +--------------------------------------------------------------------------------------+
+    |                                                                                      |
++-> +--------------------------------------------------------------------------------------+
+|
+|
++ chunk
+
+
+3) libuv reads the first request (e.g. GET /) in one go
+
++ buffer
+|
+|
++-> +--------------------------------------------------------------------------------------+
+    | GET / HTTP/1.1\r\n\r\n |                                                             |
++-> +--------------------------------------------------------------------------------------+
+|
+|
++ chunk                                     buffer->used = 18
+
+
+4) Haywire parses the request. When the end of the request if found,
+Haywire places a mark at the end of the previous chunk. However,
+since this is the previous chunk, the mark is set at the beginning of the buffer.
+
++ buffer
+|
+| + mark
+| |
+| |
++-> +--------------------------------------------------------------------------------------+
+    | GET / HTTP/1.1\r\n\r\n |                                                             |
++-> +--------------------------------------------------------------------------------------+
+|
+|
++ chunk                                     buffer->used = 18
+
+
+5) Haywire reaches the end of the chunk soon after and tries to sweep the buffer.
+Since the mark is right at the beginning of the buffer, nothing really happens.
+
+6) libuv asks for another chunk and reads 27 bytes.
+
++ buffer
+|
+| + mark
+| |
+| |
++-> +--------------------------------------------------------------------------------------+
+    | GET / HTTP/1.1\r\n\r\n | GET HTTP/1.1\r\n\r\nGET / HTT |                             |
+    +--------------------------------------------------------------------------------------+
+                             ^
+                             |
+                             |
+chunk  +---------------------+                buffer->used = 45
+                                              buffer->last_used = 18
+
+
+7) Haywire parses the second chunk and eventually it finds the end of the second request. Once
+that happens, a mark is placed at the end of the previous chunk (i.e. by advancing the underlying
+buffer by buffer->last_used bytes)
+
++ buffer
+|
+|                            + mark
+|                            |
+|                            v
++-> +--------------------------------------------------------------------------------------+
+    | GET / HTTP/1.1\r\n\r\n | GET HTTP/1.1\r\n\r\nGET / HTT |                             |
+    +--------------------------------------------------------------------------------------+
+                             ^
+                             |
+                             |
+ chunk +---------------------+                buffer->used = 45
+                                              buffer->last_used = 18
+
+8) Haywire reaches the end of the buffer and the third request is now in flight.
+Haywire sweeps everything before the mark, by copying the remainder of the data in the buffer
+back to the beginning. Any pins placed while parsing the request being discarded (i.e. first URL)
+are removed and any other pins (e.g. URL of the last request) are adjusted by the number of bytes
+being swept.
+
++ buffer
+|
+| + mark
+| |
+| |
++-> +--------------------------------------------------------------------------------------+
+    | GET HTTP/1.1\r\n\r\nGET / HTT |                                                      |
+    +--------------------------------------------------------------------------------------+
+
+                                              buffer->used = 27
+                                              buffer->last_used = 0
+
+9) libuv asks for another buffer and Haywire returns a new chunk that overlaps with the
+free space in the underlying buffer
+
++ buffer
+|
+| + mark
+| |
+| |
++-> +--------------------------------------------------------------------------------------+
+    | GET HTTP/1.1\r\n\r\nGET / HTT |                                                      |
+    +--------------------------------------------------------------------------------------+
+                                    ^
+                                    |
+   chunk +--------------------------+
+                                              buffer->used = 27
+                                              buffer->last_used = 0
+
+
+10) libuv reads the rest of the request into the new chunk. Haywire parses the chunk and the process
+repeats.
+
++ buffer
+|
+| + mark
+| |
+| |
++-> +--------------------------------------------------------------------------------------+
+    | GET HTTP/1.1\r\n\r\nGET / HTT | P / 1.1\r\n\r\n                                      |
+    +--------------------------------------------------------------------------------------+
+                                    ^
+                                    |
+   chunk +--------------------------+
+                                              buffer->used = 36
+                                              buffer->last_used = 27
+
+```
+
+

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -136,6 +136,8 @@ enum hw_http_method
 #define SETSTRING(s,val) s.value=val; s.length=STRLENOF(val)
 #define APPENDSTRING(s,val) memcpy((char*)s->value + s->length, val, STRLENOF(val)); s->length+=STRLENOF(val)
 
+typedef	void* hw_http_response;
+
 typedef struct
 {
     char* value;
@@ -150,8 +152,9 @@ typedef struct
     char* parser;
     bool tcp_nodelay;
     unsigned int listen_backlog;
+    unsigned int max_request_size;
 } configuration;
-
+    
 typedef struct
 {
     unsigned short http_major;
@@ -161,10 +164,9 @@ typedef struct
     hw_string* url;
     void* headers;
     hw_string* body;
-    int body_length;
+    size_t body_length;
+    enum {OK, SIZE_EXCEEDED, BAD_REQUEST, INTERNAL_ERROR} state;
 } http_request;
-
-typedef	void* hw_http_response;
 
 typedef void (HAYWIRE_CALLING_CONVENTION *http_request_callback)(http_request* request, hw_http_response* response, void* user_data);
 typedef void (HAYWIRE_CALLING_CONVENTION *http_response_complete_callback)(void* user_data);

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -1,7 +1,10 @@
+#include <stddef.h>
+
 #pragma once
 #include "uv.h"
 #include "http_parser.h"
 #include "http_request.h"
+#include "http_request_buffers.h"
 
 typedef struct
 {
@@ -13,4 +16,6 @@ typedef struct
     hw_string current_header_value;
     int keep_alive;
     int last_was_value;
+    enum {OPEN, CLOSING, CLOSED} state;
+    hw_request_buffer* buffer;
 } http_connection;

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -2,14 +2,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include "haywire.h"
+#include <haywire.h>
 #include "hw_string.h"
 #include "khash.h"
 #include "http_request.h"
 #include "http_response.h"
-#include "http_parser.h"
 #include "http_server.h"
-#include "http_connection.h"
 #include "server_stats.h"
 #include "route_compare_method.h"
 
@@ -38,6 +36,7 @@ static kh_inline khint_t hw_string_hash_func(hw_string* s)
 
 KHASH_INIT(hw_string_hashmap, hw_string*,  hw_string*, 1, hw_string_hash_func, hw_string_hash_equal)
 KHASH_MAP_INIT_STR(string_hashmap, char*)
+KHASH_MAP_INIT_INT64(offset_hashmap, int)
 
 void hw_print_request_headers(http_request* request)
 {
@@ -56,9 +55,14 @@ void hw_print_request_headers(http_request* request)
 
 void hw_print_body(http_request* request)
 {
-    char* body = uv__strndup(request->body->value, request->body->length + 1);
-    printf("BODY: %s\n", body);
-    free(body);
+    if (request->body->length > 0) {
+        char* body = uv__strndup(request->body->value, request->body->length);
+        printf("BODY: %s\n", body);
+        free(body);
+    }
+    else {
+        printf("BODY is empty!\n");
+    }
 }
 
 void* get_header(http_request* request, hw_string* name)
@@ -79,30 +83,31 @@ void* get_header(http_request* request, hw_string* name)
 
 void set_header(http_request* request, hw_string* name, hw_string* value)
 {
-    int ret;
+    int ret, i;
     khiter_t k;
     khash_t(hw_string_hashmap) *h = request->headers;
-    
+
+    for (i = 0; i < name->length; i++)
+    {
+        name->value[i] = tolower(name->value[i]);
+    }
+
     void* prev = get_header(request, name);
     if (prev) {
         free(prev);
     }
-    
+
     k = kh_put(hw_string_hashmap, h, name, &ret);
     kh_value(h, k) = value;
 }
 
 http_request* create_http_request(http_connection* connection)
 {
-    http_request* request = malloc(sizeof(http_request));
+    http_request* request = calloc(1, sizeof(http_request));
     request->headers = kh_init(hw_string_hashmap);
-    request->url = malloc(sizeof(hw_string));
-    request->url->length = 0;
-    request->url->value = NULL;
-    request->body_length = 0;
-    request->body = malloc(sizeof(hw_string));
-    request->body->value = NULL;
-    request->body->length = 0;
+    request->url = calloc(1, sizeof(hw_string));
+    request->body = calloc(1, sizeof(hw_string));
+    request->state = OK;
     INCREMENT_STAT(stat_requests_created_total);
     return request;
 }
@@ -110,22 +115,23 @@ http_request* create_http_request(http_connection* connection)
 void free_http_request(http_request* request)
 {
     khash_t(hw_string_hashmap) *h = request->headers;
+
     hw_string* k;
     hw_string* v;
+
     kh_foreach(h, k, v,
     {
         free((hw_string*)k);
         free((hw_string*)v);
     });
-    kh_destroy(hw_string_hashmap, request->headers);
 
-    if (request->url->length > 0)
-    {
-        free(request->url->value);
-    }
-    free(request->url); 
+    kh_destroy(hw_string_hashmap, h);
+
+    free(request->url);
     free(request->body);
+
     free(request);
+
     INCREMENT_STAT(stat_requests_destroyed_total);
 }
 
@@ -138,6 +144,14 @@ hw_string* hw_get_header(http_request* request, hw_string* key)
 int http_request_on_message_begin(http_parser* parser)
 {
     http_connection* connection = (http_connection*)parser->data;
+    if (connection->request) {
+        /* We're seeing a new request on the same connection, so it's time to free up the old one
+         * and create a new one.
+         *
+         * Note: This assumes that the request callback is synchronous. If we're ever to support async callbacks,
+         * we either need to copy all required data and pass it into the async callback or free on write instead. */
+        free_http_request(connection->request);
+    }
     connection->request = create_http_request(connection);
     return 0;
 }
@@ -145,36 +159,68 @@ int http_request_on_message_begin(http_parser* parser)
 int http_request_on_url(http_parser *parser, const char *at, size_t length)
 {
     http_connection* connection = (http_connection*)parser->data;
-    
-    // TODO: This should be zero-copy to remove the malloc/strncpy.
-    int buffer_length = sizeof(char) * length;
-    connection->request->url->value = (char *)malloc(buffer_length);
-    connection->request->url->length = buffer_length;
-    strncpy(connection->request->url->value, at, length);
-    
+    http_request* request = connection->request;
+    hw_string* url = request->url;
+
+    if (url->length) {
+        /* This is not the first URL chunk that has been seen in the buffer. Since we've already captured the initial pointer in the branch below,
+           so we can recover the URL later on, we only increment the URL length and ignore the pointer passed in as a parameter. */
+        url->length += length;
+    } else {
+        url->value = at;
+        url->length = length;
+        /* We've seen the URL start, so we need to pin it to recover it later */
+        http_request_buffer_pin(connection->buffer, url, url->value);
+    }
+
     return 0;
 }
+
+void http_request_save_current_header(http_connection* connection) {
+    hw_string* header_key_copy = hw_strdup(&connection->current_header_key);
+    hw_string* header_value_copy = hw_strdup(&connection->current_header_value);
+
+    /* We duplicate the current header key/value, so we actually need to use the new pointers as pin ids, as
+     * those will be the IDs we'll use later on to locate the headers */
+    http_request_buffer_reassign_pin(connection->buffer, &connection->current_header_key, header_key_copy);
+    http_request_buffer_reassign_pin(connection->buffer, &connection->current_header_value, header_value_copy);
+
+    /* Set headers is going to need to have the values of header key/value, so we need to make sure we get
+     * the pointers pointing at the right place in the buffer */
+    header_key_copy->value = http_request_buffer_locate(connection->buffer, header_key_copy,
+                                                        connection->current_header_key.value);
+
+    header_value_copy->value = http_request_buffer_locate(connection->buffer, header_value_copy,
+                                                          connection->current_header_value.value);
+
+    /* Save last header key/value pair that was read */
+    set_header(connection->request, header_key_copy, header_value_copy);
+}
+
 
 int http_request_on_header_field(http_parser *parser, const char *at, size_t length)
 {
     http_connection* connection = (http_connection*)parser->data;
-    int i = 0;
 
-    if (connection->last_was_value && connection->current_header_key.length > 0)
-    {
-        // Save last read header key/value pair.
-        for (i = 0; i < connection->current_header_key.length; i++)
-        {
-            connection->current_header_key.value[i] = tolower(connection->current_header_key.value[i]);
-        }
+    if (connection->last_was_value && connection->current_header_key.length > 0) {
+        http_request_save_current_header(connection);
 
-        set_header(connection->request, hw_strdup(&connection->current_header_key), hw_strdup(&connection->current_header_value));
-
-        /* Start of a new header */
         connection->current_header_key.length = 0;
+        connection->current_header_value.length = 0;
     }
-    connection->current_header_key.value = at;
-    connection->current_header_key.length = length;
+
+    if (connection->current_header_key.length > 0) {
+        /* This is not the first header chunk that has been seen in the buffer. Since we've already captured the initial pointer in the branch below,
+           so we can recover the header later on, we only increment the header length and ignore the pointer passed in as a parameter. */
+        connection->current_header_key.length += length;
+    } else {
+        /* Start of a new header key */
+        connection->current_header_key.value = at;
+        connection->current_header_key.length = length;
+        /* Pin the header key */
+        http_request_buffer_pin(connection->buffer, &connection->current_header_key, at);
+    }
+
     connection->last_was_value = 0;
     return 0;
 }
@@ -183,33 +229,27 @@ int http_request_on_header_value(http_parser *parser, const char *at, size_t len
 {
     http_connection* connection = (http_connection*)parser->data;
 
-    if (!connection->last_was_value && connection->current_header_value.length > 0)
-    {
-        /* Start of a new header */
-        connection->current_header_value.length = 0;
+    if (!connection->last_was_value) {
+        connection->current_header_value.value = at;
+        connection->current_header_value.length = length;
+        connection->last_was_value = 1;
+        /* Pin the header value */
+        http_request_buffer_pin(connection->buffer, &connection->current_header_value, at);
+    } else {
+        /* Another header value chunk, not necessarily contiguous to the other chunks seen before, so we only increment
+         * the length. When the header value is located later on, it will be guaranteedly contiguous. */
+        connection->current_header_value.length += length;
     }
-    connection->current_header_value.value = at;
-    connection->current_header_value.length = length;
-    connection->last_was_value = 1;
+
     return 0;
 }
 
 int http_request_on_headers_complete(http_parser* parser)
 {
     http_connection* connection = (http_connection*)parser->data;
-    int i = 0;
 
-    if (connection->current_header_key.length > 0)
-    {
-        if (connection->current_header_value.length > 0)
-        {
-            /* Store last header */
-            for (i = 0; i < connection->current_header_key.length; i++)
-            {
-                connection->current_header_key.value[i] = tolower(connection->current_header_key.value[i]);
-            }
-            set_header(connection->request, hw_strdup(&connection->current_header_key), hw_strdup(&connection->current_header_value));
-        }
+    if (connection->current_header_key.length > 0 && connection->current_header_value.length > 0) {
+        http_request_save_current_header(connection);
     }
     connection->current_header_key.length = 0;
     connection->current_header_value.length = 0;
@@ -225,15 +265,22 @@ int http_request_on_headers_complete(http_parser* parser)
 int http_request_on_body(http_parser *parser, const char *at, size_t length)
 {
     http_connection* connection = (http_connection*)parser->data;
+    http_request* request = connection->request;
+    hw_string* body = request->body;
     if (length != 0)
     {
-        if (connection->request->body->length == 0) {
-            connection->request->body->value = at;
-            connection->request->body->length = length;
+        if (body->length == 0) {
+            body->value = at;
+            body->length = length;
+            /* Let's pin the body so we can recover it later, even if the underlying buffers change */
+            http_request_buffer_pin(connection->buffer, body, body->value);
         } else {
-            connection->request->body->length += length;
+            body->length += length;
         }
+        
+        request->body_length = body->length;
     }
+
     return 0;
 }
 
@@ -245,7 +292,7 @@ hw_route_entry* get_route_callback(hw_string* url)
     const char* v;
      
     khash_t(string_hashmap) *h = routes;
-     
+
     kh_foreach(h, k, v,
     {
         int found = hw_route_compare_method(url, k);
@@ -258,7 +305,8 @@ hw_route_entry* get_route_callback(hw_string* url)
     return route_entry;
 }
 
-void get_404_response(http_request* request, http_response* response)
+void send_error_response(http_request* request, http_response* response, const char* error_code,
+                         const char* error_message)
 {
     hw_string status_code;
     hw_string content_type_name;
@@ -266,16 +314,18 @@ void get_404_response(http_request* request, http_response* response)
     hw_string body;
     hw_string keep_alive_name;
     hw_string keep_alive_value;
-    
-    SETSTRING(status_code, HTTP_STATUS_404);
+
+    status_code.value = error_code;
+    status_code.length = strlen(error_code);
     hw_set_response_status_code(response, &status_code);
     
     SETSTRING(content_type_name, "Content-Type");
     
     SETSTRING(content_type_value, "text/html");
     hw_set_response_header(response, &content_type_name, &content_type_value);
-    
-    SETSTRING(body, "404 Not Found");
+
+    body.value = error_message;
+    body.length = strlen(error_message);
     hw_set_body(response, &body);
     
     if (request->keep_alive)
@@ -289,53 +339,77 @@ void get_404_response(http_request* request, http_response* response)
     {
         hw_set_http_version(response, 1, 0);
     }
+
+    hw_http_response_send(response, NULL, 0);
+}
+
+/**
+ * Ensures that the URL, body and header pointers are correct.
+ * This is because the underlying buffers might have been reallocated/resized,
+ * so we can't use the pointers of where data chunks (e.g. URL start) were originally seen.
+ */
+void http_request_locate_members(http_connection* connection)
+{
+    hw_request_buffer* buffer = connection->buffer;
+    http_request* request = connection->request;
+    request->url->value = http_request_buffer_locate(buffer, request->url, request->url->value);
+    request->body->value = http_request_buffer_locate(buffer, request->body, request->body->value);
+
+    hw_string* header_name;
+    hw_string* header_value;
+
+    khash_t(hw_string_hashmap) *h = request->headers;
+    kh_foreach(h, header_name, header_value, {
+        header_name->value = http_request_buffer_locate(buffer, header_name, header_name->value);
+        header_value->value = http_request_buffer_locate(buffer, header_value, header_value->value);
+    });
 }
 
 int http_request_on_message_complete(http_parser* parser)
 {
     http_connection* connection = (http_connection*)parser->data;
-    hw_route_entry* route_entry = get_route_callback(connection->request->url);
-    hw_string* response_buffer;
-    hw_write_context* write_context;
+    http_request* request = connection->request;
     hw_http_response* response = hw_create_http_response(connection);
-    
-    if (route_entry != NULL)
-    {
-        route_entry->callback(connection->request, response, route_entry->user_data);
-    }
-    else
-    {
-        // 404 Not Found.
-        write_context = malloc(sizeof(hw_write_context));
-        write_context->connection = connection;
-        write_context->request = connection->request;
-        write_context->callback = 0;
-        get_404_response(connection->request, (http_response*)response);
-        response_buffer = create_response_buffer(response);
-        http_server_write_response(write_context, response_buffer);
-        free(response_buffer);
-        hw_free_http_response(response);
-    }
-    
-    free_http_request(connection->request);
-    connection->request = NULL;
-    
-    return 0;
-}
 
-void hw_http_response_send(hw_http_response* response, void* user_data, http_response_complete_callback callback)
-{
-    hw_write_context* write_context = malloc(sizeof(hw_write_context));
-    http_response* resp = (http_response*)response;
-    hw_string* response_buffer = create_response_buffer(response);
+    char* error = NULL;
+
+    if (connection->request->state == SIZE_EXCEEDED) {
+        // 413 Request entity too large
+        error = HTTP_STATUS_413;
+    } else if (connection->request->state == BAD_REQUEST) {
+        // 400 Bad Request
+        error = HTTP_STATUS_400;
+    } else if (connection->request->state == INTERNAL_ERROR) {
+        // 500 Internal Server Error
+    } else {
+        http_request_locate_members(connection);
+
+        hw_route_entry* route_entry = request != NULL ? get_route_callback(request->url) : NULL;
+
+        if (route_entry != NULL)
+        {
+            route_entry->callback(request, response, route_entry->user_data);
+        }
+        else
+        {
+            // 404 Not Found.
+            error = HTTP_STATUS_404;
+        }
+
+        /* Let's tell the buffer that we don't care about the data that was read before that is not currently
+         * being processed, so it can be swept later on.
+         *
+         * Since the HTTP parser doesn't tell us exactly where the request ends, we can be exact when creating a mark,
+         * otherwise we could discard everything up to, and including, the end of the current request.
+         *
+         * Instead, we create a mark that will be set at the end of the last chunk that was read before the one
+         * currently being processed and on which callback fired. */
+        http_request_buffer_mark(connection->buffer);
+    }
     
-    write_context->connection = resp->connection;
-    write_context->request = resp->connection->request;
-    write_context->user_data = user_data;
-    write_context->callback = callback;
-    http_server_write_response(write_context, response_buffer);
-    resp->sent = 1;
-    
-    free(response_buffer);
-    hw_free_http_response(response);
+    if (error) {
+        send_error_response(request, (http_response*)response, error, error);
+    }
+
+    return 0;
 }

--- a/src/haywire/http_request.h
+++ b/src/haywire/http_request.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #pragma once
 #include "uv.h"
 #include "http_parser.h"

--- a/src/haywire/http_request_buffers.c
+++ b/src/haywire/http_request_buffers.c
@@ -1,0 +1,239 @@
+#include <stdbool.h>
+#include <errno.h>
+#include "haywire.h"
+#include "http_request_buffers.h"
+
+#define DEFAULT_BUFFER_SHRINKSIZE 65536
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+KHASH_MAP_INIT_INT64(pointer_hashmap, void*)
+
+typedef struct {
+    size_t max_size;
+    size_t size;
+    size_t mark;
+    size_t used;
+    size_t used_before;
+    void* current;
+    khash_t(pointer_hashmap)* offsets;
+    bool offsets_active;
+} http_request_buffer;
+
+void http_request_buffer_consume(hw_request_buffer* buf, size_t consumed) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+    buffer->used_before = buffer->used;
+    buffer->used += consumed;
+}
+
+void http_request_buffer_mark(hw_request_buffer* buf) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+    /* unfortunately, the parser doesn't tell us where the request ends exactly,
+     * so the only thing we can be sure is that it ends in the current buffer chunk, so anything before it can
+     * effectively be swept, so we're placing the mark at that point now. */
+    buffer->mark = buffer->used_before;
+}
+
+void http_request_buffer_sweep(hw_request_buffer* buf) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+    void* pointer;
+    int offset;
+    int used = buffer->used - buffer->mark;
+
+    if (buffer->mark > 0) {
+        bool offsets_active = false;
+
+        if (buffer->used > 0) {
+            /* Move data beyond the mark to the beginning of the buffer.
+             * While we should avoid memory copies, this is relatively infrequent and will only really copy a
+             * significant amount of data if requests are pipelined. Otherwise, we'll just be copying the last chunk
+             * that was read back to the beginning of the buffer. */
+            memcpy(buffer->current, buffer->current + buffer->mark, used);
+        }
+
+        if (buffer->size > DEFAULT_BUFFER_SHRINKSIZE && buffer->used < DEFAULT_BUFFER_SHRINKSIZE) {
+            /* Shrink buffer */
+            buffer->size = DEFAULT_BUFFER_SHRINKSIZE;
+            buffer->current = realloc(buffer->current, buffer->size);
+            if (!buffer->current) {
+                errno = ENOMEM;
+                buffer->size = 0;
+            }
+        }
+
+        /* Update offsets */
+        if (buffer->used) {
+            kh_foreach(buffer->offsets, pointer, offset, {
+                khiter_t offset_key = kh_get(pointer_hashmap, buffer->offsets, pointer);
+
+                if (offset <= buffer->mark) {
+                    /* Delete offsets that pointed to bytes before the mark */
+                    kh_del(pointer_hashmap, buffer->offsets, offset_key);
+                } else {
+                    /* There's at least one offset beyond the mark, so the offsets are active and should be considered
+                     * when locating pointers. We need to shift the offset back by the width of the mark */
+                    offsets_active = true;
+                    kh_value(buffer->offsets, offset_key) = offset - buffer->mark;
+                }
+            });
+        } else {
+            /* the buffer is now empty, so we don't need to keep offsets */
+            kh_clear(pointer_hashmap, buffer->offsets);
+        }
+
+        buffer->mark = 0;
+        buffer->used = used;
+        buffer->offsets_active = offsets_active;
+    }
+}
+
+hw_request_buffer* http_request_buffer_init(size_t max_size) {
+    http_request_buffer* buffer = malloc(sizeof(http_request_buffer));
+    buffer->max_size = max_size;
+    buffer->size = 0;
+    buffer->used = 0;
+    buffer->mark = 0;
+    buffer->used_before = 0;
+    buffer->current = NULL;
+    buffer->offsets = kh_init(pointer_hashmap);
+    buffer->offsets_active = false;
+    return buffer;
+}
+
+void http_request_buffer_chunk(hw_request_buffer* buf, hw_request_buffer_chunk* chunk) {
+    http_request_buffer *buffer = (http_request_buffer *) buf;
+    chunk->size = buffer->size ? buffer->size - buffer->used : 0;
+    chunk->buffer = buffer->current + buffer->used;
+}
+
+bool http_request_buffer_alloc(hw_request_buffer* buf, size_t requested_size) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+    bool ret = true;
+    void* previous = NULL;
+
+    size_t requested_size_capped = MIN(buffer->max_size, requested_size);
+
+    if (!buffer->current) {
+        buffer->current = malloc(requested_size_capped);
+        if (!buffer->current) {
+            buffer->size = 0;
+            errno = ENOMEM;
+            ret = false;
+        } else {
+            buffer->size = requested_size_capped;
+        }
+    } else if (buffer->used * 2 < buffer->size) {
+        /* ignoring allocation size unless we're above 50% usage */
+    } else if (buffer->size + requested_size_capped <= buffer->max_size) {
+        /* time to reallocate memory and re-point anything using the buffer */
+        previous = buffer->current;
+
+        buffer->current = realloc(buffer->current, buffer->size + requested_size_capped);
+        buffer->size += requested_size_capped;
+
+        if (!buffer->current) {
+            buffer->size = 0;
+            errno = ENOMEM;
+            ret = false;
+        } else if (buffer->current != previous) {
+            buffer->offsets_active = true;
+        }
+    } else {
+        /* maximum request size exceeded */
+        errno = ERANGE;
+        buffer->size = 0;
+        ret = false;
+    }
+
+    return ret;
+}
+
+void http_request_buffer_print(hw_request_buffer* buf) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+
+    printf("Buffer: current=%u; size=%u; used=%u\n", buffer->current, buffer->size, buffer->used);
+    printf("    0\t");
+    for (int i = 0; i < buffer->used; i++) {
+        if (((char*) buffer->current)[i] == '\n') {
+            printf("\\n");
+        } else if (((char*) buffer->current)[i] == '\r') {
+            printf("\\r");
+        } else {
+            printf("%c", ((char*) buffer->current)[i]);
+        }
+
+        if ((i + 1) % 10 == 0) {
+            printf("\n%5d\t", (i + 1) / 10);
+        } else {
+            printf("\t");
+        }
+    }
+    printf("\n");
+
+    void* pointer;
+    int offset;
+    kh_foreach(buffer->offsets, pointer, offset, {
+        printf("\tPointer %u -> offset=%u\n", pointer, offset);
+    });
+    printf("----\n");
+}
+
+void http_request_buffer_pin(hw_request_buffer* buf, void* key, void* pointer) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+
+    khiter_t offset_key = kh_get(pointer_hashmap, buffer->offsets, key);
+
+    int offset = pointer - buffer->current;
+    int ret;
+
+    int is_missing = (offset_key == kh_end(buffer->offsets));
+    if (is_missing) {
+        offset_key = kh_put(pointer_hashmap, buffer->offsets, key, &ret);
+    } 
+
+    kh_value(buffer->offsets, offset_key) = offset;
+}
+
+void http_request_buffer_reassign_pin(hw_request_buffer* buf, void* old_key, void* new_key) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+
+    khiter_t old_offset_key = kh_get(pointer_hashmap, buffer->offsets, old_key);
+
+    int offset;
+    int ret;
+
+    int is_missing = (old_offset_key == kh_end(buffer->offsets));
+    if (!is_missing) {
+        offset = kh_val(buffer->offsets, old_offset_key);
+
+        khiter_t new_offset_key = kh_put(pointer_hashmap, buffer->offsets, new_key, &ret);
+        kh_value(buffer->offsets, new_offset_key) = offset;
+        old_offset_key = kh_get(pointer_hashmap, buffer->offsets, old_key);
+        kh_del(pointer_hashmap, buffer->offsets, old_offset_key);
+    }
+}
+
+void* http_request_buffer_locate(hw_request_buffer* buf, void* key, void* default_pointer) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+    void* location = default_pointer;
+    khiter_t offset_key = kh_get(pointer_hashmap, buffer->offsets, key);
+
+    int offset, is_missing;
+
+    if (buffer->offsets_active) {
+        is_missing = (offset_key == kh_end(buffer->offsets));
+        if (!is_missing) {
+            offset = kh_value(buffer->offsets, offset_key);
+            location = buffer->current + offset;
+        }
+    }
+
+    return location;
+}
+
+void http_request_buffer_destroy(hw_request_buffer* buf) {
+    http_request_buffer* buffer = (http_request_buffer*) buf;
+    kh_destroy(pointer_hashmap, buffer->offsets);
+    free(buffer->current);
+    free(buffer);
+}

--- a/src/haywire/http_request_buffers.h
+++ b/src/haywire/http_request_buffers.h
@@ -1,0 +1,81 @@
+#pragma once
+#include <stdbool.h>
+#include "khash.h"
+#include "haywire.h"
+
+typedef struct {
+    void* buffer;
+    size_t size;
+} hw_request_buffer_chunk;
+
+typedef void* hw_request_buffer;
+
+/**
+ * Initializes a new buffer. The caller is responsible for calling http_request_buffer_destroy to free up memory.
+ */
+hw_request_buffer* http_request_buffer_init(size_t max_size);
+
+/**
+ * Signals that "size" bytes from the buffer are now in use.
+ */
+void http_request_buffer_consume(hw_request_buffer* buffer, size_t size);
+
+/**
+ * Marks all buffer chunks up to the last one allocated (exclusive) for removal when
+ * http_request_buffer_sweep gets called.
+ */
+void http_request_buffer_mark(hw_request_buffer* buffer);
+
+/**
+ * Sweeps all buffer chunks up to the mark. Data for the last chunk is copied to the beginning of the buffer
+ * and the offsets are updates accordingly.
+ */
+void http_request_buffer_sweep(hw_request_buffer* buffer);
+
+/**
+ * Prints the buffer.
+ */
+void http_request_buffer_print(hw_request_buffer* buffer);
+
+/**
+ * Ensures that there's will be a sizable chunk available when the it's requested via http_request_buffer_chunk.
+ * This will ensure that the requested size doesn't exceed the maximum buffer size and will try to
+ * re-use the existing underlying buffers if there's sufficient space still to be used.
+ * Therefore, "requested_size" is just a hint, and not necessarily the size that will be allocated.
+ *
+ * Returns true if the allocation succeeds, false otherwise (errno is set accordingly).
+ */
+bool http_request_buffer_alloc(hw_request_buffer* buf, size_t requested_size);
+
+/**
+ * Returns a new buffer chunk to be used by request reader.
+ */
+void http_request_buffer_chunk(hw_request_buffer* buffer, hw_request_buffer_chunk* chunk);
+
+/**
+ * Informs the buffer manager that *pointer is a memory region of interest and that will have to be made available to
+ * the caller eventually, when http_request_buffer_locate is called. The pin is given a key by the caller so it can be
+ * retrieved later. Pins will be overwritten if the same key is used multiple times.
+ */
+void http_request_buffer_pin(hw_request_buffer* buffer, void* key, void* pointer);
+
+/**
+ * Allows the caller to assign a new key to a pin.
+ */
+void http_request_buffer_reassign_pin(hw_request_buffer* buffer, void* old_key, void* new_key);
+
+/**
+ * Returns the pointer to the memory region associated with a pin. If there isn't a pin with that key, then
+ * the value of "default_pointer" is returned.
+ *
+ * This call guarantees that the memory region returned is contiguous, i.e. even if multiple chunks non contiguous
+ * chunks were used before, the pointer returned by this function points to a memory region that can be read
+ * sequentially. It's the responsibility of the caller to know how long that region is, by keeping track of its
+ * length as it's being read in.
+ */
+void* http_request_buffer_locate(hw_request_buffer* buffer, void* key, void* default_pointer);
+
+/**
+ * Destroys the buffer and any underlying buffer chunks.
+ */
+void http_request_buffer_destroy(hw_request_buffer* buffer);

--- a/src/haywire/http_response.h
+++ b/src/haywire/http_response.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "haywire.h"
 #include "http_connection.h"
 
@@ -11,6 +12,7 @@ typedef struct
 typedef struct
 {
     http_connection* connection;
+    http_request* request;
     unsigned short http_major;
     unsigned short http_minor;
     hw_string status_code;
@@ -19,6 +21,14 @@ typedef struct
     hw_string body;
     int sent;
 } http_response;
+
+typedef struct
+{
+    http_connection* connection;
+    http_request* request;
+    void* user_data;
+    http_response_complete_callback callback;
+} hw_write_context;
 
 hw_http_response hw_create_http_response(http_connection* connection);
 hw_string* create_response_buffer(hw_http_response* response);

--- a/src/haywire/http_response_cache.h
+++ b/src/haywire/http_response_cache.h
@@ -3,5 +3,5 @@
 #include "haywire.h"
 
 void initialize_http_request_cache();
-hw_string* get_cached_request(char* http_status);
+hw_string* get_cached_request(const char* http_status);
 void http_request_cache_configure_listener(uv_loop_t* loop, uv_async_t* handle);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -3,20 +3,13 @@
 #include "haywire.h"
 #include "http_connection.h"
 #include "http_parser.h"
+#include "http_response.h"
 
 typedef struct
 {
     http_request_callback callback;
     void* user_data;
 } hw_route_entry;
-
-typedef struct
-{
-    http_connection* connection;
-    http_request* request;
-    void* user_data;
-    http_response_complete_callback callback;
-} hw_write_context;
 
 union stream_handle
 {

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -22,12 +22,28 @@ hw_string* hw_strdup(hw_string* tocopy)
 }
 
 int hw_strcmp(hw_string* a, hw_string* b) {
-    return strncmp(a->value, b->value, a->length > b->length ? a->length : b->length);
+    int ret;
+    
+    if (a->length > b->length) {
+        ret = strncmp(a->value, b->value, b->length);
+        if (!ret) {
+            ret = 1;
+        }
+    } else if (a->length == b->length) {
+        ret = strncmp(a->value, b->value, a->length);
+    } else {
+        ret = strncmp(a->value, b->value, a->length);
+        if (!ret) {
+            ret = -1;
+        }
+    }
+    
+    return ret;
 }
 
 void append_string(hw_string* destination, hw_string* source)
 {
-    void* location = (char*)destination->value + destination->length;
+    void* location = (void*) (destination->value + destination->length);
     memcpy(location, source->value, source->length);
     destination->length += source->length;
 }

--- a/src/haywire/route_compare_method.c
+++ b/src/haywire/route_compare_method.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "haywire.h"
+#include <haywire.h>
 #include "hw_string.h"
 #include "route_compare_method.h"
 

--- a/src/samples/hello_world/haywire_hello_world.conf
+++ b/src/samples/hello_world/haywire_hello_world.conf
@@ -5,3 +5,4 @@
 listen_address = 0.0.0.0
 listen_port = 8000
 tcp_nodelay = 1
+max_request_size = 1048576

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -11,6 +11,48 @@ void response_complete(void* user_data)
 {
 }
 
+void get_ping(http_request* request, hw_http_response* response, void* user_data)
+{
+    hw_string status_code;
+    hw_string content_type_name;
+    hw_string content_type_value;
+    hw_string body;
+    hw_string keep_alive_name;
+    hw_string keep_alive_value;
+    hw_string route_matched_name;
+    hw_string route_matched_value;
+    
+    hw_print_request_headers(request);
+    hw_print_body(request);
+    
+    SETSTRING(status_code, HTTP_STATUS_200);
+    hw_set_response_status_code(response, &status_code);
+    
+    SETSTRING(content_type_name, "Content-Type");
+    
+    SETSTRING(content_type_value, "text/html");
+    hw_set_response_header(response, &content_type_name, &content_type_value);
+    
+    body.value = request->body->value;
+    body.length = request->body->length;
+    hw_set_body(response, &body);
+    
+    if (request->keep_alive)
+    {
+        SETSTRING(keep_alive_name, "Connection");
+        
+        SETSTRING(keep_alive_value, "Keep-Alive");
+        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
+    }
+    else
+    {
+        hw_set_http_version(response, 1, 0);
+    }
+    
+    hw_http_response_send(response, "user_data", response_complete);
+}
+
+
 void get_root(http_request* request, hw_http_response* response, void* user_data)
 {
     hw_string status_code;
@@ -45,18 +87,13 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
         hw_set_http_version(response, 1, 0);
     }
     
-    SETSTRING(route_matched_name, "Route-Matched");
-    route_matched_value.value = (char *) user_data;
-    route_matched_value.length = strlen((char *) user_data);
-    hw_set_response_header(response, &route_matched_name, &route_matched_value);
-    
     hw_http_response_send(response, "user_data", response_complete);
 }
 
 int main(int args, char** argsv)
 {
-    char route[] = "/";
-    char sub_route[] = "/*";
+    char root_route[] = "/";
+    char ping_route[] = "/ping";
     configuration config;
     config.http_listen_address = "0.0.0.0";
 
@@ -65,14 +102,15 @@ int main(int args, char** argsv)
     opt_flag_int(conf, &config.http_listen_port, "port", 8000, "Port to listen on.");
     opt_flag_int(conf, &config.thread_count, "threads", 0, "Number of threads to use.");
     opt_flag_string(conf, &config.parser, "parser", "http_parser", "HTTP parser to use");
+    opt_flag_int(conf, &config.max_request_size, "max_request_size", 1048576, "Maximum request size. Defaults to 1MB.");
     opt_flag_bool(conf, &config.tcp_nodelay, "tcp_nodelay", "If present, enables tcp_nodelay (i.e. disables Nagle's algorithm).");
     opt_flag_int(conf, &config.listen_backlog, "listen_backlog", 0, "Maximum size of the backlog when accepting connection. Defaults to SOMAXCONN.");
     args = opt_config_parse(conf, args, argsv);
 
     hw_init_with_config(&config);
     
-    hw_http_add_route(route, get_root, route);
-    hw_http_add_route(sub_route, get_root, sub_route);
+    hw_http_add_route(ping_route, get_ping, NULL);
+    hw_http_add_route(root_route, get_root, NULL);
     
     hw_http_open();
 


### PR DESCRIPTION
…anteed that we'll get one and only one fully formed request on each combination of alloc/read calls.

Previously, we were assuming that the alloc callback was only called once per request and that the read callback was called when all the data was available.
Unfortunately, that's not the case, and the read callback may be called when only a fraction of the incoming data is available, especially under high concurrency.

Buffers are now managed in http_request_buffers.*. We use a mark/sweep technique to get rid of requests previously handled by a connection whenever a new buffer chunk is fully processed. This allows us to keep a relatively small buffer. Also, it's now possible to register interest in a given memory region by placing a pin on it and retrieving its location once the request has been fully read in.

We will now also deal with bad requests that were causing crashes before, requests that are too long to be processed and that could cause us to run out of memory. Unknown errors are also dealt with now, by returning an appropriate error code.

Removed redundant header imports.

Makes #93 redundant.

# Benchmarks

My tests were run on two m4.xlarge machines on AWS with 4 cores each, with the server being run with: `./build/hello_world --threads 4`. The benchmark was run using wrk: `./wrk -c 300 -t 300 -d 1m -s pipelined_get.lua  --latency http://172.31.5.65:8000 -- 64`.

## Results

### master
```
Running 1m test @ http://172.31.5.65:8000
  300 threads and 300 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   103.53ms  173.03ms   1.99s    91.22%
    Req/Sec     2.45k     1.56k   49.58k    68.31%
  Latency Distribution
     50%   23.92ms
     75%  146.86ms
     90%  254.43ms
     99%  834.11ms
  34420176 requests in 1.00m, 5.64GB read
  Socket errors: connect 0, read 0, write 0, timeout 28
Requests/sec: 572704.23
Transfer/sec:     96.13MB
```

### this change
```
Running 1m test @ http://172.31.5.65:8000
  300 threads and 300 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    87.12ms  145.41ms   1.80s    91.38%
    Req/Sec     2.69k     1.64k   44.80k    54.73%
  Latency Distribution
     50%   18.67ms
     75%  128.81ms
     90%  217.65ms
     99%  677.48ms
  39001682 requests in 1.00m, 5.59GB read
  Socket errors: connect 0, read 0, write 0, timeout 8
Requests/sec: 648948.92
Transfer/sec:     95.31MB
```

cc'ing @jpz @botdes @violetta-baeva 