### PR TITLE
Copy backlog from config to context.

### DIFF
--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -214,6 +214,7 @@ int hw_http_open()
             int rc = 0;
             struct server_ctx* ctx = servers + i;
             ctx->index = i;
+            ctx->listen_backlog = config->listen_backlog;
             
             rc = uv_sem_init(&ctx->semaphore, 0);
             rc = uv_thread_create(&ctx->thread_id, connection_consumer_start, ctx);


### PR DESCRIPTION
Fixes issue where ctx->listen_backlog is left at zero resulting in a dead service on startup.