### PR TITLE
Add SO_REUSEPORT for both multi-threaded and multi-process support.

### DIFF
--- a/include/haywire.h
+++ b/include/haywire.h
@@ -149,6 +149,7 @@ typedef struct
     char* http_listen_address;
     unsigned int http_listen_port;
     unsigned int thread_count;
+    char* balancer;
     char* parser;
     bool tcp_nodelay;
     unsigned int listen_backlog;

--- a/src/haywire/connection_consumer.h
+++ b/src/haywire/connection_consumer.h
@@ -47,3 +47,4 @@ struct ipc_server_ctx
 };
 
 void connection_consumer_start(void *arg);
+void connection_consumer_close(uv_async_t* handle, int status);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -37,3 +37,4 @@ void http_stream_on_close(uv_handle_t* handle);
 int http_server_write_response_single(hw_write_context* write_context, hw_string* response);
 void http_server_after_write(uv_write_t* req, int status);
 void http_stream_on_read_http_parser(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf);
+void reuseport_thread_start(void *arg);

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -101,6 +101,7 @@ int main(int args, char** argsv)
     conf = opt_config_init();
     opt_flag_int(conf, &config.http_listen_port, "port", 8000, "Port to listen on.");
     opt_flag_int(conf, &config.thread_count, "threads", 0, "Number of threads to use.");
+    opt_flag_string(conf, &config.balancer, "balancer", "ipc", "Method to load balance threads.");
     opt_flag_string(conf, &config.parser, "parser", "http_parser", "HTTP parser to use");
     opt_flag_int(conf, &config.max_request_size, "max_request_size", 1048576, "Maximum request size. Defaults to 1MB.");
     opt_flag_bool(conf, &config.tcp_nodelay, "tcp_nodelay", "If present, enables tcp_nodelay (i.e. disables Nagle's algorithm).");


### PR DESCRIPTION
This PR adds the support for `SO_REUSEPORT` load balancing option along side the `IPC` load balancing option.

There's a bug in this PR somewhere though. If you run 1 thread in N Haywire processes you get almost double the performance as if you run N threads in 1 Haywire process.

```
./build/hello_world --threads 20 --balancer reuseport
3.1 million requests/second
```

```
for i in `seq 20`; do ./build/hello_world --balancer reuseport & done
5.4 million requests/second
```